### PR TITLE
商品一覧表示機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: :index
   
   def index
-    #@items = Item.order('created_at DESC')
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: :index
-  
+
   def index
     @items = Item.all.order('created_at DESC')
   end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -10,7 +10,7 @@ class Category < ActiveHash::Base
     { id: 8, name: '家電・スマホ・カメラ' },
     { id: 9, name: 'スポーツ・レジャー' },
     { id: 10, name: 'ハンドメイド' },
-    { id: 11, name: 'その他' },
+    { id: 11, name: 'その他' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,7 +7,7 @@ class Item < ApplicationRecord
   belongs_to :prefecture
   belongs_to :scheduled_delivery
   has_one_attached :image
-  
+
   with_options presence: true do
     validates :name
     validates :info
@@ -20,9 +20,9 @@ class Item < ApplicationRecord
     validates :scheduled_delivery_id
   end
 
-  validates :price, format: {with: /\A[0-9]+\z/, message: '半角数字を使用してください' }
-  validates :price, numericality: {greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999 }
-  
+  validates :price, format: { with: /\A[0-9]+\z/, message: '半角数字を使用してください' }
+  validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
+
   with_options numericality: { other_than: 1 } do
     validates :category_id
     validates :sales_status_id
@@ -30,5 +30,4 @@ class Item < ApplicationRecord
     validates :prefecture_id
     validates :scheduled_delivery_id
   end
-  
 end

--- a/app/models/sales_status.rb
+++ b/app/models/sales_status.rb
@@ -6,7 +6,7 @@ class SalesStatus < ActiveHash::Base
     { id: 4, name: '目立った傷や汚れなし' },
     { id: 5, name: 'やや傷や汚れあり' },
     { id: 6, name: '傷や汚れあり' },
-    { id: 7, name: '全体的に状態が悪い' },
+    { id: 7, name: '全体的に状態が悪い' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/scheduled_delivery.rb
+++ b/app/models/scheduled_delivery.rb
@@ -3,7 +3,7 @@ class ScheduledDelivery < ActiveHash::Base
     { id: 1, name: '--' },
     { id: 2, name: '1日〜2日で発送' },
     { id: 3, name: '2日〜3日で発送' },
-    { id: 4, name: '4日〜7日で発送' },
+    { id: 4, name: '4日〜7日で発送' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/shipping_fee_status.rb
+++ b/app/models/shipping_fee_status.rb
@@ -2,7 +2,7 @@ class ShippingFeeStatus < ActiveHash::Base
   self.data = [
     { id: 1, name: '--' },
     { id: 2, name: '着払い(購入者負担)' },
-    { id: 3, name: '送料込み(出品者負担)' },
+    { id: 3, name: '送料込み(出品者負担)' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   has_many :items
 
   with_options presence: true do
-    validates :nick_name
+    validates :nickname
     validates :birth_date
 
     with_options format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: '全角文字を使用してください' } do

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,14 +126,17 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      
+    <% if @items != nil %>
+    <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
+          <%= image_tag item.image, class: "item-img" %>
+          
+          <%#購入機能実装後に行う %>
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+          <%#<div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# //商品が売れていればsold outを表示しましょう %>
@@ -141,10 +144,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee_status_id %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,10 +156,11 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      
+    <% end %>
+    <% else %>
+      
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -174,8 +178,8 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+    <% end %>
+      
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,8 +127,8 @@
     <ul class='item-lists'>
 
       
-    <% if @items != nil %>
-    <% @items.each do |item| %>
+    <% if @items.length != 0 %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
@@ -156,11 +156,8 @@
         </div>
         <% end %>
       </li>
-      
-    <% end %>
+      <% end %>
     <% else %>
-      
-
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -179,7 +176,6 @@
         <% end %>
       </li>
     <% end %>
-      
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -147,7 +147,7 @@
             <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= item.price %>円<br><%= item.shipping_fee_status_id %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee_status.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,14 +1,14 @@
 FactoryBot.define do
   factory :item do
-    name {Faker::Lorem.word}
-    info {Faker::Lorem.sentence}
-    price {Faker::Commerce.price(range: 300..9999999, as_string: true)}
-    category_id {Faker::Number.between(from: 2, to: 11)}
-    sales_status_id {Faker::Number.between(from: 2, to: 7)}
-    shipping_fee_status_id {Faker::Number.between(from: 2, to: 3)}
-    prefecture_id {Faker::Number.between(from: 2, to: 48)}
-    scheduled_delivery_id {Faker::Number.between(from: 2, to: 4)}
-    association :user 
+    name { Faker::Lorem.word }
+    info { Faker::Lorem.sentence }
+    price { Faker::Commerce.price(range: 300..9_999_999, as_string: true) }
+    category_id { Faker::Number.between(from: 2, to: 11) }
+    sales_status_id { Faker::Number.between(from: 2, to: 7) }
+    shipping_fee_status_id { Faker::Number.between(from: 2, to: 3) }
+    prefecture_id { Faker::Number.between(from: 2, to: 48) }
+    scheduled_delivery_id { Faker::Number.between(from: 2, to: 4) }
+    association :user
 
     after(:build) do |item|
       item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -35,82 +35,82 @@ RSpec.describe Item, type: :model do
       it 'カテゴリーが空では登録できない' do
         @item.category_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category can't be blank", "Category is not a number")
+        expect(@item.errors.full_messages).to include("Category can't be blank", 'Category is not a number')
       end
       it '商品の状態が空では登録できない' do
         @item.sales_status_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Sales status can't be blank", "Sales status is not a number")
+        expect(@item.errors.full_messages).to include("Sales status can't be blank", 'Sales status is not a number')
       end
       it '配送料の負担が空では登録できない' do
         @item.shipping_fee_status_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping fee status can't be blank", "Shipping fee status is not a number")
+        expect(@item.errors.full_messages).to include("Shipping fee status can't be blank", 'Shipping fee status is not a number')
       end
       it '発送元の地域が空では登録できない' do
         @item.prefecture_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture can't be blank", "Prefecture is not a number")
+        expect(@item.errors.full_messages).to include("Prefecture can't be blank", 'Prefecture is not a number')
       end
       it '発送までの日数が空では登録できない' do
         @item.scheduled_delivery_id = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Scheduled delivery can't be blank", "Scheduled delivery is not a number")
+        expect(@item.errors.full_messages).to include("Scheduled delivery can't be blank", 'Scheduled delivery is not a number')
       end
       it '商品価格が空では登録できない' do
         @item.price = ''
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price can't be blank", "Price is not a number")
+        expect(@item.errors.full_messages).to include("Price can't be blank", 'Price is not a number')
       end
       it 'categoryidが1では登録できない' do
         @item.category_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
+        expect(@item.errors.full_messages).to include('Category must be other than 1')
       end
       it 'sales_status_idが1では登録できない' do
         @item.sales_status_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Sales status must be other than 1")
+        expect(@item.errors.full_messages).to include('Sales status must be other than 1')
       end
       it 'shipping_fee_status_idが1では登録できない' do
         @item.shipping_fee_status_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping fee status must be other than 1")
+        expect(@item.errors.full_messages).to include('Shipping fee status must be other than 1')
       end
       it 'prefecture_idが1では登録できない' do
         @item.prefecture_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Prefecture must be other than 1")
+        expect(@item.errors.full_messages).to include('Prefecture must be other than 1')
       end
       it 'scheduled_delivery_idが1では登録できない' do
         @item.scheduled_delivery_id = 1
         @item.valid?
-        expect(@item.errors.full_messages).to include("Scheduled delivery must be other than 1")
+        expect(@item.errors.full_messages).to include('Scheduled delivery must be other than 1')
       end
       it '商品価格が299円以下では登録できない' do
         @item.price = 200
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be greater than or equal to 300")
+        expect(@item.errors.full_messages).to include('Price must be greater than or equal to 300')
       end
       it '商品価格が10,000,000円以上では登録できない' do
-        @item.price = 10000100
+        @item.price = 10_000_100
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price must be less than or equal to 9999999")
+        expect(@item.errors.full_messages).to include('Price must be less than or equal to 9999999')
       end
       it '商品価格が半角英語では登録できない' do
         @item.price = 'test'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it '商品価格が全角文字では登録できない' do
         @item.price = 'あいうえお'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it '商品価格が全角数字では登録できない' do
         @item.price = '１００００'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price is not a number")
+        expect(@item.errors.full_messages).to include('Price is not a number')
       end
       it 'ユーザーが紐付いていなければ登録できない' do
         @item.user = nil


### PR DESCRIPTION
#What
商品一覧表示機能の実装

#Why
出品された商品を表示しないと購入するための情報がなくなるから

プルリクエストを出した後に修正点を見つけたので再度プッシュしておきます。

商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/b8a95da6a21dbca9a2405f639e3a0991
商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/21d25882996387a8f339acbea4b7fb19
